### PR TITLE
Remove redundant npm dependency

### DIFF
--- a/package.json
+++ b/package.json
@@ -51,7 +51,6 @@
     "ngx-spinner": "^6.1.2",
     "ngx-toastr": "^9.1.1",
     "ngx-toggle-switch": "^2.0.5",
-    "npm": "^6.4.1",
     "primeicons": "^1.0.0",
     "primeng": "^6.1.6",
     "rxjs": "^6.0.0",


### PR DESCRIPTION

Hello rajeshworld123!

It seems like you have npm as one of your (dev-) dependency in liv_production.
Since you actually need npm to install the dependencies it's redundant to
have npm itself as (dev-) dependency. 

Therefore I've removed it and made this PR, merge if you want :)
Be sure to re-run `npm i` or `yarn` to actualize your lock files.

Beep boop, I'm a bot.
